### PR TITLE
Clean up project specs and compile for Java 8 target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ hs_err_pid*
 # Build Files
 **/build
 /bin/
+/target/
+
+# Maven
+settings.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,21 @@
+ARTIFACT_VERSION=1.1.0
+ARTIFACT_GROUP=com.amplitude
+
+POM_PACKAGING=jar
+POM_DESCRIPTION=Amplitude Java SDK
+
+POM_URL=https://github.com/amplitude/Amplitude-Java
+POM_SCM_URL=https://github.com/amplitude/Amplitude-Java
+POM_SCM_CONNECTION=scm:git:http://github.com/amplitude/Amplitude-Java
+POM_SCM_DEV_CONNECTION=scm:git:git@github.com:amplitude/Amplitude-Java.git
+POM_LICENCE_NAME=The MIT License
+POM_LICENCE_URL=http://www.opensource.org/licenses/mit-license.php
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=amplitude_sdk_dev
+POM_DEVELOPER_NAME=Amplitude SDK Developers
+POM_DEVELOPER_EMAIL=sdk.dev@amplitude.com
+POM_DEVELOPER_ORG=Amplitude
+POM_DEVELOPER_ORG_URL=https://amplitude.com/
+
+RELEASE_REPOSITORY_URL=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots/

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'Amplitude-Java-SDK'
+rootProject.name = 'amplitude-java-sdk'
 include 'main'
 project(':main').projectDir = file('src/main')
 include 'demo'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'Amplitude Java SDK'
+rootProject.name = 'Amplitude-Java-SDK'
 include 'main'
 project(':main').projectDir = file('src/main')
 include 'demo'

--- a/src/main/build.gradle
+++ b/src/main/build.gradle
@@ -11,8 +11,8 @@ compileJava {
 
 apply plugin: 'idea'
 
-group 'com.amplitude'
-version '1.1.0'
+group ARTIFACT_GROUP
+version ARTIFACT_VERSION
 
 repositories {
     jcenter()

--- a/src/main/build.gradle
+++ b/src/main/build.gradle
@@ -1,11 +1,18 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id 'maven-publish'
+    id 'signing'
+}
+
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
 }
 
 apply plugin: 'idea'
-apply plugin: 'java'
 
 group 'com.amplitude'
+version '1.1.0'
 
 repositories {
     jcenter()
@@ -13,6 +20,7 @@ repositories {
     maven {
         url "https://plugins.gradle.org/m2/"
     }
+    mavenLocal()
 }
 
 idea {
@@ -27,7 +35,51 @@ dependencies {
     implementation 'org.json:json:20201115'
 }
 
-jar {
-    archiveBaseName = 'Amplitude-Java'
-    archiveVersion = '1.0.0'
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+// ======== For SDK Releases ========
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'java-sdk'
+            from components.java
+            pom {
+                name = POM_DESCRIPTION
+                description = POM_DESCRIPTION
+                url = POM_URL
+                licenses {
+                    license {
+                        name = POM_LICENCE_NAME
+                        url = POM_LICENCE_URL
+                    }
+                }
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
+                        email = POM_DEVELOPER_EMAIL
+                    }
+                }
+                scm {
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_DEV_CONNECTION
+                    url = POM_SCM_URL
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = 'mySecureRepository'
+            credentials(org.gradle.api.credentials.PasswordCredentials)
+            url = uri(RELEASE_REPOSITORY_URL)
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
 }

--- a/src/main/java/com/amplitude/Constants.java
+++ b/src/main/java/com/amplitude/Constants.java
@@ -5,7 +5,7 @@ public interface Constants {
     String  API_URL                 = "https://api2.amplitude.com/2/httpapi";
     long    NETWORK_TIMEOUT_MILLIS  = 10000;
     String  SDK_LIBRARY             = "amplitude-java";
-    String  SDK_VERSION             = "1.0.0";
+    String  SDK_VERSION             = "1.1.0";
 
     int     MAX_PROPERTY_KEYS       = 1024;
     int     MAX_STRING_LENGTH       = 1000;

--- a/src/main/java/com/amplitude/Constants.java
+++ b/src/main/java/com/amplitude/Constants.java
@@ -10,7 +10,6 @@ public interface Constants {
     int     MAX_PROPERTY_KEYS       = 1024;
     int     MAX_STRING_LENGTH       = 1000;
 
-    int     HTTP_STATUS_CONTINUE    = 100;
     int     HTTP_STATUS_BAD_REQ     = 400;
 
 }


### PR DESCRIPTION
The library should be compiled for Java 8 as it does not have any special features beyond Java 8, and should be compiled properly on projects that still use Java 8.