### PR TITLE
chore: Add intelliJ generated files exception to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ hs_err_pid*
 *.iml
 *.ipr
 *.iws
+.project
+.classpath
+.settings
 
 # Build Files
 **/build


### PR DESCRIPTION
### Summary

Add intelliJ generated files exception to .gitignore

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no