### PR TITLE
fix: Log every possible status code

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -4,13 +4,14 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'adopt'
+          architecture: x64
       - uses: actions/checkout@v2
       - name: Test with Gradle
         run: gradle test:test

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Set up JDK 8
         uses: actions/setup-java@v2

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 8
         uses: actions/setup-java@v2

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ hs_err_pid*
 
 # Maven
 settings.xml
+
+.DS_Store

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -16,6 +16,8 @@ public class Amplitude {
   private HttpCallMode httpCallMode;
   private HttpCall httpCall;
   private HttpTransport httpTransport;
+  private int eventUploadThreshold = Constants.EVENT_BUF_COUNT;
+  private int eventUploadPeriodMillis = Constants.EVENT_BUF_TIME_MILLIS;
 
   /**
    * Private internal constructor for Amplitude. Please use `getInstance(String name)` or
@@ -95,6 +97,30 @@ public class Amplitude {
   }
 
   /**
+   * Sets event upload threshold. The SDK will attempt to batch upload unsent events
+   * every eventUploadPeriodMillis milliseconds, or if the unsent event count exceeds the
+   * event upload threshold.
+   *
+   * @param eventUploadThreshold the event upload threshold
+   */
+  public Amplitude setEventUploadThreshold(int eventUploadThreshold) {
+    this.eventUploadThreshold = eventUploadThreshold;
+    return this;
+  }
+
+  /**
+   * Sets event upload period millis. The SDK will attempt to batch upload unsent events * every
+   * eventUploadPeriodMillis milliseconds, or if the unsent event count exceeds the * event upload
+   * threshold.
+   *
+   * @param eventUploadPeriodMillis the event upload period millis
+   */
+  public Amplitude setEventUploadPeriodMillis(int eventUploadPeriodMillis) {
+    this.eventUploadPeriodMillis = eventUploadPeriodMillis;
+    return this;
+  }
+
+  /**
    * Set event callback which are triggered after event sent
    *
    * @param callbacks AmplitudeCallbacks or null to clean up.
@@ -110,7 +136,7 @@ public class Amplitude {
    */
   public synchronized void logEvent(Event event) {
     eventsToSend.add(event);
-    if (eventsToSend.size() >= Constants.EVENT_BUF_COUNT) {
+    if (eventsToSend.size() >= this.eventUploadThreshold) {
       flushEvents();
     } else {
       scheduleFlushEvents();
@@ -146,7 +172,7 @@ public class Amplitude {
           new Thread(
               () -> {
                 try {
-                  Thread.sleep(Constants.EVENT_BUF_TIME_MILLIS);
+                  Thread.sleep(this.eventUploadPeriodMillis);
                 } catch (InterruptedException e) {
 
                 }

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -210,6 +210,9 @@ class HttpTransport {
       case PAYLOAD_TOO_LARGE:
         shouldRetry = true;
         break;
+      case TIMEOUT:
+          triggerEventCallbacks(events, response.code, response.error);
+        break;
       case INVALID:
         if (events.size() == 1) {
           shouldRetry = false;

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -56,9 +56,7 @@ class HttpTransport {
                 triggerEventCallbacks(events, response.code, "Event sent success.");
               } else if (status == Status.FAILED) {
                   triggerEventCallbacks(events, response.code, "Event sent Failed.");
-              } else if (status == Status.TIMEOUT) {
-                  triggerEventCallbacks(events, response.code, "Event sent Timeout.");
-              } else {
+              }  else {
                   triggerEventCallbacks(events, response.code, "Unknown response status.");
               }
             })
@@ -313,7 +311,8 @@ class HttpTransport {
   protected boolean shouldRetryForStatus(Status status) {
     return (status == Status.INVALID
         || status == Status.PAYLOAD_TOO_LARGE
-        || status == Status.RATELIMIT);
+        || status == Status.RATELIMIT
+        || status == Status.TIMEOUT);
   }
 
   private void triggerEventCallbacks(List<Event> events, int status, String message) {

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -54,6 +54,12 @@ class HttpTransport {
                 retryEvents(events, response);
               } else if (status == Status.SUCCESS) {
                 triggerEventCallbacks(events, response.code, "Event sent success.");
+              } else if (status == Status.FAILED) {
+                  triggerEventCallbacks(events, response.code, "Event sent Failed.");
+              } else if (status == Status.TIMEOUT) {
+                  triggerEventCallbacks(events, response.code, "Event sent Timeout.");
+              } else {
+                  triggerEventCallbacks(events, response.code, "Unknown response status.");
               }
             })
         .exceptionally(

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -210,9 +210,6 @@ class HttpTransport {
       case PAYLOAD_TOO_LARGE:
         shouldRetry = true;
         break;
-      case TIMEOUT:
-          triggerEventCallbacks(events, response.code, response.error);
-        break;
       case INVALID:
         if (events.size() == 1) {
           shouldRetry = false;

--- a/src/test/java/com/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/amplitude/AmplitudeTest.java
@@ -44,12 +44,11 @@ public class AmplitudeTest {
     amplitude.init(apiKey);
     amplitude.useBatchMode(useBatch);
     amplitude.setLogMode(AmplitudeLog.LogMode.OFF);
+    amplitude.setEventUploadThreshold(5);
     List<Event> events = EventsGenerator.generateEvents(10, 5, 6);
     HttpCall httpCall = getMockHttpCall(amplitude, useBatch);
-    Response response = new Response();
-    response.code = 200;
-    response.status = Status.SUCCESS;
-    CountDownLatch latch = new CountDownLatch(1);
+    Response response = ResponseUtil.getSuccessResponse();
+    CountDownLatch latch = new CountDownLatch(2);
     when(httpCall.makeRequest(anyList()))
         .thenAnswer(
             invocation -> {
@@ -68,7 +67,7 @@ public class AmplitudeTest {
       amplitude.logEvent(event);
     }
     assertTrue(latch.await(1L, TimeUnit.SECONDS));
-    verify(httpCall, times(1)).makeRequest(anyList());
+    verify(httpCall, times(2)).makeRequest(anyList());
   }
 
   @ParameterizedTest
@@ -136,6 +135,31 @@ public class AmplitudeTest {
     httpCallField.setAccessible(true);
     HttpCall httpCall = (HttpCall) httpCallField.get(amplitude);
     assertEquals(httpCall.getApiUrl(), useBatch ? Constants.BATCH_API_URL : Constants.API_URL);
+  }
+
+  @Test
+  public void testSetEventUploadThreshold() throws NoSuchFieldException, IllegalAccessException {
+    Amplitude amplitude = Amplitude.getInstance("test");
+    amplitude.init(apiKey);
+    int updatedEventUploadThreshold = 5;
+    amplitude.setEventUploadThreshold(updatedEventUploadThreshold);
+    Field eventUploadThresholdField = amplitude.getClass().getDeclaredField("eventUploadThreshold");
+    eventUploadThresholdField.setAccessible(true);
+    int eventUploadThreshold = (Integer) eventUploadThresholdField.get(amplitude);
+    assertEquals(eventUploadThreshold, updatedEventUploadThreshold);
+  }
+
+  @Test
+  public void testSetEventUploadPeriodMillis() throws NoSuchFieldException, IllegalAccessException {
+    Amplitude amplitude = Amplitude.getInstance("test");
+    amplitude.init(apiKey);
+    int updatedEventUploadPeriodMillis = 20000;
+    amplitude.setEventUploadPeriodMillis(updatedEventUploadPeriodMillis);
+    Field eventUploadPeriodMillisdField =
+        amplitude.getClass().getDeclaredField("eventUploadPeriodMillis");
+    eventUploadPeriodMillisdField.setAccessible(true);
+    int eventUploadPeriodMillis = (Integer) eventUploadPeriodMillisdField.get(amplitude);
+    assertEquals(eventUploadPeriodMillis, updatedEventUploadPeriodMillis);
   }
 
   @Test

--- a/src/test/java/com/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/amplitude/AmplitudeTest.java
@@ -40,7 +40,7 @@ public class AmplitudeTest {
   public void testLogEventSuccess(boolean useBatch)
       throws InterruptedException, NoSuchFieldException, IllegalAccessException,
           AmplitudeInvalidAPIKeyException {
-    Amplitude amplitude = Amplitude.getInstance("test");
+    Amplitude amplitude = Amplitude.getInstance("testsuccess");
     amplitude.init(apiKey);
     amplitude.useBatchMode(useBatch);
     amplitude.setLogMode(AmplitudeLog.LogMode.OFF);

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -41,7 +41,7 @@ public class HttpTransportTest {
     "INVALID, true",
     "RATELIMIT, true",
     "PAYLOAD_TOO_LARGE, true",
-    "TIMEOUT, false",
+    "TIMEOUT, true",
     "FAILED, false",
     "UNKNOWN, false"
   })

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -245,17 +245,12 @@ public class HttpTransportTest {
         Response timeoutResponse = ResponseUtil.getTimeoutResponse();
         Response successResponse = ResponseUtil.getSuccessResponse();
         HttpCall httpCall = mock(HttpCall.class);
-        CountDownLatch latch = new CountDownLatch(2);
+        CountDownLatch latch = new CountDownLatch(1);
         when(httpCall.makeRequest(anyList()))
         .thenAnswer(
                 invocation -> {
                     latch.countDown();
                     return timeoutResponse;
-                })
-        .thenAnswer(
-                invocation -> {
-                    latch.countDown();
-                    return successResponse;
                 });
 
         List<Event> events = EventsGenerator.generateEvents(10);
@@ -271,9 +266,73 @@ public class HttpTransportTest {
         httpTransport.setCallbacks(callbacks);
         httpTransport.retryEvents(events, timeoutResponse);
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
-        verify(httpCall, times(2)).makeRequest(anyList());
+        verify(httpCall, times(1)).makeRequest(anyList());
         for (int i = 0; i < events.size(); i++) {
-            assertEquals(200, resultMap.get(events.get(i)));
+            assertEquals(408, resultMap.get(events.get(i)));
+        }
+    }
+
+    @Test
+    public void testFailedResponse()
+            throws AmplitudeInvalidAPIKeyException, InterruptedException {
+        Response failedResponse = ResponseUtil.getFailedResponse();
+        HttpCall httpCall = mock(HttpCall.class);
+        CountDownLatch latch = new CountDownLatch(1);
+        when(httpCall.makeRequest(anyList()))
+                .thenAnswer(
+                        invocation -> {
+                            latch.countDown();
+                            return failedResponse;
+                        });
+
+        List<Event> events = EventsGenerator.generateEvents(10);
+        Map<Event, Integer> resultMap = new HashMap<>();
+        AmplitudeCallbacks callbacks =
+                new AmplitudeCallbacks() {
+                    @Override
+                    public void onLogEventServerResponse(Event event, int status, String message) {
+                        resultMap.put(event, status);
+                    }
+                };
+        httpTransport.setHttpCall(httpCall);
+        httpTransport.setCallbacks(callbacks);
+        httpTransport.sendEventsWithRetry(events);
+        assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        verify(httpCall, times(1)).makeRequest(anyList());
+        for (int i = 0; i < events.size(); i++) {
+            assertEquals(500, resultMap.get(events.get(i)));
+        }
+    }
+
+    @Test
+    public void testUnknownResponse()
+            throws AmplitudeInvalidAPIKeyException, InterruptedException {
+        Response unknownResponse = ResponseUtil.getUnknownResponse();
+        HttpCall httpCall = mock(HttpCall.class);
+        CountDownLatch latch = new CountDownLatch(1);
+        when(httpCall.makeRequest(anyList()))
+                .thenAnswer(
+                        invocation -> {
+                            latch.countDown();
+                            return unknownResponse;
+                        });
+
+        List<Event> events = EventsGenerator.generateEvents(10);
+        Map<Event, Integer> resultMap = new HashMap<>();
+        AmplitudeCallbacks callbacks =
+                new AmplitudeCallbacks() {
+                    @Override
+                    public void onLogEventServerResponse(Event event, int status, String message) {
+                        resultMap.put(event, status);
+                    }
+                };
+        httpTransport.setHttpCall(httpCall);
+        httpTransport.setCallbacks(callbacks);
+        httpTransport.sendEventsWithRetry(events);
+        assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        verify(httpCall, times(1)).makeRequest(anyList());
+        for (int i = 0; i < events.size(); i++) {
+            assertEquals(0, resultMap.get(events.get(i)));
         }
     }
 }

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -245,12 +245,17 @@ public class HttpTransportTest {
         Response timeoutResponse = ResponseUtil.getTimeoutResponse();
         Response successResponse = ResponseUtil.getSuccessResponse();
         HttpCall httpCall = mock(HttpCall.class);
-        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(2);
         when(httpCall.makeRequest(anyList()))
         .thenAnswer(
                 invocation -> {
                     latch.countDown();
                     return timeoutResponse;
+                })
+        .thenAnswer(
+                invocation -> {
+                    latch.countDown();
+                    return successResponse;
                 });
 
         List<Event> events = EventsGenerator.generateEvents(10);
@@ -266,9 +271,9 @@ public class HttpTransportTest {
         httpTransport.setCallbacks(callbacks);
         httpTransport.retryEvents(events, timeoutResponse);
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
-        verify(httpCall, times(1)).makeRequest(anyList());
+        verify(httpCall, times(2)).makeRequest(anyList());
         for (int i = 0; i < events.size(); i++) {
-            assertEquals(408, resultMap.get(events.get(i)));
+            assertEquals(200, resultMap.get(events.get(i)));
         }
     }
 

--- a/src/test/java/com/amplitude/ResponseUtil.java
+++ b/src/test/java/com/amplitude/ResponseUtil.java
@@ -1,6 +1,7 @@
 package com.amplitude;
 
 import java.util.Arrays;
+import java.util.ResourceBundle;
 
 import org.json.JSONObject;
 
@@ -49,5 +50,12 @@ class ResponseUtil {
       rateLimitResponse.rateLimitBody.put("exceededDailyQuotaDevices", exceededDailyQuotaDevices);
     }
     return rateLimitResponse;
+  }
+
+  public static Response getTimeoutResponse() {
+    Response timeoutResponse = new Response();
+    timeoutResponse.status = Status.TIMEOUT;
+    timeoutResponse.code = 408;
+    return timeoutResponse;
   }
 }

--- a/src/test/java/com/amplitude/ResponseUtil.java
+++ b/src/test/java/com/amplitude/ResponseUtil.java
@@ -58,4 +58,18 @@ class ResponseUtil {
     timeoutResponse.code = 408;
     return timeoutResponse;
   }
+
+  public static Response getFailedResponse() {
+    Response failedResponse = new Response();
+    failedResponse.status = Status.FAILED;
+    failedResponse.code = 500;
+    return failedResponse;
+  }
+
+  public static Response getUnknownResponse() {
+    Response unknownResponse = new Response();
+    unknownResponse.status = Status.UNKNOWN;
+    unknownResponse.code = 0;
+    return unknownResponse;
+  }
 }


### PR DESCRIPTION

### Summary

In HttpTransport class, sendEventWithRetry method, adding failed, timeout and other unknown status callback logs.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no