### PR TITLE
feat: add print debug info to console for client flush and event sending with response detail

### DIFF
--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -174,6 +174,7 @@ public class Amplitude {
     if (eventsToSend.size() > 0) {
       List<Event> eventsInTransit = new ArrayList<>(eventsToSend);
       eventsToSend.clear();
+      logger.log(logger.getTimeStamp(), eventsInTransit.size() + " events to flush");
       httpTransport.sendEventsWithRetry(eventsInTransit);
     }
   }
@@ -205,5 +206,17 @@ public class Amplitude {
               });
       flushThread.start();
     }
+  }
+
+  public void debug(String message) {
+    logger.log(logger.getTimeStamp(), message);
+  }
+
+  public void warn(String message) {
+    logger.warn(logger.getTimeStamp(), message);
+  }
+
+  public void error(String message) {
+    logger.error(logger.getTimeStamp(), message);
   }
 }

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -174,7 +174,6 @@ public class Amplitude {
     if (eventsToSend.size() > 0) {
       List<Event> eventsInTransit = new ArrayList<>(eventsToSend);
       eventsToSend.clear();
-      logger.log(logger.getTimeStamp(), eventsInTransit.size() + " events to flush");
       httpTransport.sendEventsWithRetry(eventsInTransit);
     }
   }
@@ -206,17 +205,5 @@ public class Amplitude {
               });
       flushThread.start();
     }
-  }
-
-  public void debug(String message) {
-    logger.log(logger.getTimeStamp(), message);
-  }
-
-  public void warn(String message) {
-    logger.warn(logger.getTimeStamp(), message);
-  }
-
-  public void error(String message) {
-    logger.error(logger.getTimeStamp(), message);
   }
 }

--- a/src/main/java/com/amplitude/AmplitudeLog.java
+++ b/src/main/java/com/amplitude/AmplitudeLog.java
@@ -8,10 +8,6 @@ public class AmplitudeLog {
   private LogMode logMode = LogMode.ERROR;
   private static SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
-  public static String getTimeStamp(){
-    return sdfDate.format(new Date());
-  }
-
   public void setLogMode(LogMode logMode) {
     this.logMode = logMode;
   }

--- a/src/main/java/com/amplitude/AmplitudeLog.java
+++ b/src/main/java/com/amplitude/AmplitudeLog.java
@@ -2,6 +2,7 @@ package com.amplitude;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 public class AmplitudeLog {
   private LogMode logMode = LogMode.ERROR;
@@ -15,11 +16,7 @@ public class AmplitudeLog {
     this.logMode = logMode;
   }
 
-  public LogMode getLogMode() {
-    return logMode;
-  }
-
-  public void log(String tag, String message) {
+  public void debug(String tag, String message) {
     log(tag, message, LogMode.DEBUG);
   }
 
@@ -29,6 +26,14 @@ public class AmplitudeLog {
 
   public void error(String tag, String message) {
     log(tag, message, LogMode.ERROR);
+  }
+
+  public void debug(String tag, List<Event> events, Response response) {
+    if (logMode == LogMode.DEBUG) {
+      String debugMessage = sdfDate.format(new Date()) + " " + tag + ": ";
+      debugMessage += "Events count " + events.size() + ".\n" + response.toString();
+      System.out.println(debugMessage);
+    }
   }
 
   public void log(String tag, String message, LogMode messageMode) {

--- a/src/main/java/com/amplitude/AmplitudeLog.java
+++ b/src/main/java/com/amplitude/AmplitudeLog.java
@@ -1,10 +1,22 @@
 package com.amplitude;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class AmplitudeLog {
   private LogMode logMode = LogMode.ERROR;
+  private static SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+  public static String getTimeStamp(){
+    return sdfDate.format(new Date());
+  }
 
   public void setLogMode(LogMode logMode) {
     this.logMode = logMode;
+  }
+
+  public LogMode getLogMode() {
+    return logMode;
   }
 
   public void log(String tag, String message) {

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -90,10 +90,8 @@ class HttpTransport {
           try {
             response = httpCall.makeRequest(events);
             if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
-                StringBuilder debugMessage = new StringBuilder();
-                debugMessage.append("Sending ").append(events.size()).append(" events. \n")
-                        .append(response.toString());
-                logger.log(logger.getTimeStamp(), debugMessage.toString());
+                String debugMessage = "Sending " + events.size() + " events. \n" + response.toString();
+                logger.log(logger.getTimeStamp(), debugMessage);
             }
           } catch (AmplitudeInvalidAPIKeyException e) {
             throw new CompletionException(e);
@@ -198,10 +196,9 @@ class HttpTransport {
       throws AmplitudeInvalidAPIKeyException {
     Response response = httpCall.makeRequest(events);
       if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
-          StringBuilder debugMessage = new StringBuilder();
-          debugMessage.append("Retry for userId ").append(userId).append(", deviceId ").append(deviceId)
-                  .append(". Events count: ").append(events.size()).append(".\n").append(response.toString());
-          logger.log(logger.getTimeStamp(), debugMessage.toString());
+          String debugMessage = "Retry for userId " + userId + ", deviceId " + deviceId
+                  + ". Events count: " + events.size() + ".\n" + response.toString();
+          logger.log(logger.getTimeStamp(), debugMessage);
       }
     boolean shouldRetry = true;
     boolean shouldReduceEventCount = false;

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -91,8 +91,8 @@ class HttpTransport {
             response = httpCall.makeRequest(events);
             if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
                 StringBuilder debugMessage = new StringBuilder();
-                debugMessage.append("Sending ").append(events.size()).append(" events. Response status: ")
-                        .append(response.code).append(' ').append(response.status.name());
+                debugMessage.append("Sending ").append(events.size()).append(" events. \n")
+                        .append(response.toString());
                 logger.log(logger.getTimeStamp(), debugMessage.toString());
             }
           } catch (AmplitudeInvalidAPIKeyException e) {
@@ -200,8 +200,7 @@ class HttpTransport {
       if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
           StringBuilder debugMessage = new StringBuilder();
           debugMessage.append("Retry for userId ").append(userId).append(", deviceId ").append(deviceId)
-                  .append(". Events count: ").append(events.size()).append(". Response status: ").append(response.code)
-                  .append(' ').append(response.status.name());
+                  .append(". Events count: ").append(events.size()).append(".\n").append(response.toString());
           logger.log(logger.getTimeStamp(), debugMessage.toString());
       }
     boolean shouldRetry = true;

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -89,6 +89,12 @@ class HttpTransport {
           Response response = null;
           try {
             response = httpCall.makeRequest(events);
+            if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
+                StringBuilder debugMessage = new StringBuilder();
+                debugMessage.append("Sending ").append(events.size()).append(" events. Response status: ")
+                        .append(response.code).append(' ').append(response.status.name());
+                logger.log(logger.getTimeStamp(), debugMessage.toString());
+            }
           } catch (AmplitudeInvalidAPIKeyException e) {
             throw new CompletionException(e);
           }
@@ -191,6 +197,13 @@ class HttpTransport {
   private EventsRetryResult retryEventsOnce(String userId, String deviceId, List<Event> events)
       throws AmplitudeInvalidAPIKeyException {
     Response response = httpCall.makeRequest(events);
+      if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
+          StringBuilder debugMessage = new StringBuilder();
+          debugMessage.append("Retry for userId ").append(userId).append(", deviceId ").append(deviceId)
+                  .append(". Events count: ").append(events.size()).append(". Response status: ").append(response.code)
+                  .append(' ').append(response.status.name());
+          logger.log(logger.getTimeStamp(), debugMessage.toString());
+      }
     boolean shouldRetry = true;
     boolean shouldReduceEventCount = false;
     int[] eventIndicesToRemove = new int[] {};

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -89,10 +89,7 @@ class HttpTransport {
           Response response = null;
           try {
             response = httpCall.makeRequest(events);
-            if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
-                String debugMessage = "Sending " + events.size() + " events. \n" + response.toString();
-                logger.log(logger.getTimeStamp(), debugMessage);
-            }
+            logger.debug("SEND", events, response);
           } catch (AmplitudeInvalidAPIKeyException e) {
             throw new CompletionException(e);
           }
@@ -195,11 +192,7 @@ class HttpTransport {
   private EventsRetryResult retryEventsOnce(String userId, String deviceId, List<Event> events)
       throws AmplitudeInvalidAPIKeyException {
     Response response = httpCall.makeRequest(events);
-      if (logger.getLogMode() == AmplitudeLog.LogMode.DEBUG) {
-          String debugMessage = "Retry for userId " + userId + ", deviceId " + deviceId
-                  + ". Events count: " + events.size() + ".\n" + response.toString();
-          logger.log(logger.getTimeStamp(), debugMessage);
-      }
+    logger.debug("RETRY", events, response);
     boolean shouldRetry = true;
     boolean shouldReduceEventCount = false;
     int[] eventIndicesToRemove = new int[] {};

--- a/src/main/java/com/amplitude/Response.java
+++ b/src/main/java/com/amplitude/Response.java
@@ -112,14 +112,18 @@ public class Response {
     JSONObject json = new JSONObject();
     json.put("code", this.code);
     json.put("status", this.status.name());
-    if (this.error != null)
+    if (this.error != null) {
       json.put("error", this.error);
-    if (this.successBody != null)
+    }
+    if (this.successBody != null) {
       json.put("successBody", this.successBody);
-    if (this.invalidRequestBody != null)
+    }
+    if (this.invalidRequestBody != null) {
       json.put("invalidRequestBody", this.invalidRequestBody);
-    if (this.rateLimitBody != null)
+    }
+    if (this.rateLimitBody != null) {
       json.put("rateLimitBody", this.rateLimitBody);
+    }
     return json.toString(4);
   }
 }

--- a/src/main/java/com/amplitude/Response.java
+++ b/src/main/java/com/amplitude/Response.java
@@ -107,4 +107,19 @@ public class Response {
     Collections.sort(invalidIndices);
     return invalidIndices;
   }
+
+  public String toString() {
+    JSONObject json = new JSONObject();
+    json.put("code", this.code);
+    json.put("status", this.status.name());
+    if (this.error != null)
+      json.put("error", this.error);
+    if (this.successBody != null)
+      json.put("successBody", this.successBody);
+    if (this.invalidRequestBody != null)
+      json.put("invalidRequestBody", this.invalidRequestBody);
+    if (this.rateLimitBody != null)
+      json.put("rateLimitBody", this.rateLimitBody);
+    return json.toString(4);
+  }
 }

--- a/src/test/java/com/amplitude/AmplitudeLogTest.java
+++ b/src/test/java/com/amplitude/AmplitudeLogTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 

--- a/src/test/java/com/amplitude/AmplitudeLogTest.java
+++ b/src/test/java/com/amplitude/AmplitudeLogTest.java
@@ -6,10 +6,14 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import com.amplitude.util.EventsGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,8 +53,17 @@ public class AmplitudeLogTest {
     assertEquals(expectedErrorLog, errContent.toString().trim());
     amplitudeLog.warn("Test", "warn message");
     assertEquals(expectedWarnLog, outContent.toString().trim());
-    amplitudeLog.log("Test", "debug message");
+    amplitudeLog.debug("Test", "debug message");
     assertEquals(expectedDebugLog, outContent.toString().trim());
+  }
+
+  @Test
+  public void testDebugWithEventsResponse() {
+    amplitudeLog.setLogMode(AmplitudeLog.LogMode.DEBUG);
+    List<Event> events = EventsGenerator.generateEvents(10);
+    Response response = ResponseUtil.getSuccessResponse();
+    amplitudeLog.debug("TEST", events, response);
+    assertEquals("TEST: Events count 10.\n{\n    \"code\": 200,\n    \"status\": \"SUCCESS\"\n}", outContent.toString().substring(23).trim());
   }
 
   static Stream<Arguments> logArguments() {


### PR DESCRIPTION
### Summary

When logger set to debug mode:
print to console how many events are flushed by Amplitude client
print to console response detail for events sending requests
print to console response detail for events retry requests

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->