### PR TITLE
feat: add a demo for customer who wants to send large amount of historical events using batch mode

### DIFF
--- a/src/demo/java/com/demo/amplitude/DemoController.java
+++ b/src/demo/java/com/demo/amplitude/DemoController.java
@@ -13,7 +13,7 @@ public class DemoController {
   @RequestMapping("/")
   public String index() {
     Amplitude amplitude = Amplitude.getInstance("INSTANCE_NAME");
-    amplitude.init("8e07b9d451a7d07bd33f6e9ba5870f21");
+    amplitude.init("");
     amplitude.logEvent(new Event("Test Event", "test_user_id"));
     amplitude.setLogMode(AmplitudeLog.LogMode.DEBUG);
     AmplitudeCallbacks callbacks =

--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -11,15 +11,21 @@ import java.util.concurrent.TimeUnit;
 public class LocalUploadDemo {
 
     public static void main(String[] args) throws InterruptedException{
+        // Create and initialize Amplitude client
         Amplitude client = Amplitude.getInstance();
         client.init("");
+
         // use batch mode for higher throttling limits
         client.useBatchMode(true);
+
         // this config can print debug info into console, including response body of each requests
         client.setLogMode(AmplitudeLog.LogMode.DEBUG);
+
         // for large amount of events to send, config a higher update threshold to upload more events in one request
         // payload size limit for batch api is 20MB, max events per request is 2000
+        // https://developers.amplitude.com/docs/batch-event-upload-api#feature-comparison-between-httpapi-2httpapi--batch
         client.setEventUploadThreshold(1500);
+
         // config client to record throttled userId and deviceId. shouldWait(event) will return true if userid or deviceid was throttled
         // can wait a short period of time and continue
         client.setRecordThrottledId(true);

--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -1,24 +1,42 @@
 package com.demo.amplitude;
 
 import com.amplitude.Amplitude;
+import com.amplitude.AmplitudeCallbacks;
 import com.amplitude.AmplitudeLog;
 import com.amplitude.Event;
 import org.json.JSONObject;
+
 import java.util.concurrent.TimeUnit;
 
 public class LocalUploadDemo {
+
     public static void main(String[] args) throws InterruptedException{
         Amplitude client = Amplitude.getInstance();
-        client.init("44270dfba966dafe46554de66e088877");
+        client.init("");
+        // use batch mode for higher throttling limits
         client.useBatchMode(true);
+        // this config can print debug info into console, including response body of each requests
         client.setLogMode(AmplitudeLog.LogMode.DEBUG);
+        // for large amount of events to send, config a higher update threshold to upload more events in one request
+        // payload size limit for batch api is 20MB, max events per request is 2000
         client.setEventUploadThreshold(1500);
+        // config client to record throttled userId and deviceId. shouldWait(event) will return true if userid or deviceid was throttled
+        // can wait a short period of time and continue
+        client.setRecordThrottledId(true);
+        AmplitudeCallbacks callback = new AmplitudeCallbacks() {
+            @Override
+            public void onLogEventServerResponse(Event event, int status, String message) {
+                // call back functions here
+                System.out.println(event.eventType + " " + event.userId + " " + status + " " + message);
+            }
+        };
+        client.setCallbacks(callback);
         for (int i = 0; i < 10000000; i++){
-            while (client.shouldWait()) {
-                System.out.println("Wait for flushing events");
+            Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B" + (i % 5000));
+            while (client.shouldWait(ampEvent)) {
+                System.out.println("Client is busy. Waiting for log event " + ampEvent.eventType);
                 TimeUnit.SECONDS.sleep(5L);
             }
-            Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B");
             ampEvent.userProperties = new JSONObject()
                     .put("property1", "p"+i)
                     .put("property2", "p"+i)

--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -1,0 +1,31 @@
+package com.demo.amplitude;
+
+import com.amplitude.Amplitude;
+import com.amplitude.AmplitudeLog;
+import com.amplitude.Event;
+import org.json.JSONObject;
+import java.util.concurrent.TimeUnit;
+
+public class LocalUploadDemo {
+    public static void main(String[] args) throws InterruptedException{
+        Amplitude client = Amplitude.getInstance();
+        client.init("44270dfba966dafe46554de66e088877");
+        client.useBatchMode(true);
+        client.setLogMode(AmplitudeLog.LogMode.DEBUG);
+        client.setEventUploadThreshold(1500);
+        for (int i = 0; i < 10000000; i++){
+            while (client.shouldWait()) {
+                System.out.println("Wait for flushing events");
+                TimeUnit.SECONDS.sleep(5L);
+            }
+            Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B");
+            ampEvent.userProperties = new JSONObject()
+                    .put("property1", "p"+i)
+                    .put("property2", "p"+i)
+                    .put("property3", "p"+i)
+                    .put("property4", "p"+i)
+                    .put("property5", "p"+i);
+            client.logEvent(ampEvent);
+        }
+    }
+}

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -215,11 +215,12 @@ public class Amplitude {
     }
   }
 
-  public boolean shouldWait() {
-    if (eventsToSend.size() > eventUploadThreshold || httpTransport.shoudWait()) {
-      return true;
-    }
-    return false;
+  public boolean shouldWait(Event event) {
+    return eventsToSend.size() > eventUploadThreshold || httpTransport.shouldWait(event);
+  }
+
+  public void setRecordThrottledId(boolean record) {
+    httpTransport.setRecordThrottledId(record);
   }
 
   private void updateHttpCall(HttpCallMode updatedHttpCallMode) {

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -215,6 +215,13 @@ public class Amplitude {
     }
   }
 
+  public boolean shouldWait() {
+    if (eventsToSend.size() > eventUploadThreshold || httpTransport.shoudWait()) {
+      return true;
+    }
+    return false;
+  }
+
   private void updateHttpCall(HttpCallMode updatedHttpCallMode) {
     httpCallMode = updatedHttpCallMode;
 

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -215,10 +215,25 @@ public class Amplitude {
     }
   }
 
+  /**
+   * Check the status of the client, return true if any of the following situation:
+   * 1. Events sit in memory waiting for flush are more than flush threshold
+   * 2. Events in retry buffer are more than 16,000
+   * 3. When setRecordThrottledId(true), the userId or deviceId of the input event was throttled and retry attempt for the userId/deviceId not finished.
+   * Can be called before logEvent(event) and add some wait time if return true.
+   *
+   * @param event The event to be sent.
+   * @return true if client is busy or event may be throttled.
+   */
   public boolean shouldWait(Event event) {
     return eventsToSend.size() > eventUploadThreshold || httpTransport.shouldWait(event);
   }
 
+  /**
+   * Config whether the client record the recent throttled userId/deviceId and make suggestion base on it.
+   *
+   * @param record true to record
+   */
   public void setRecordThrottledId(boolean record) {
     httpTransport.setRecordThrottledId(record);
   }

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -18,6 +18,7 @@ public class Amplitude {
   private HttpTransport httpTransport;
   private int eventUploadThreshold = Constants.EVENT_BUF_COUNT;
   private int eventUploadPeriodMillis = Constants.EVENT_BUF_TIME_MILLIS;
+  private Object eventQueueLock = new Object();
 
   /**
    * A dictionary of key-value pairs that represent additional instructions for server save operation.
@@ -156,7 +157,7 @@ public class Amplitude {
    *
    * @param event The event to be sent
    */
-  public synchronized void logEvent(Event event) {
+  public void logEvent(Event event) {
     logEvent(event, null, null);
   }
 
@@ -166,7 +167,7 @@ public class Amplitude {
    * @param event The event to be sent
    * @param extra The extra unstructured data for middleware
    */
-  public synchronized void logEvent(Event event, MiddlewareExtra extra) {
+  public void logEvent(Event event, MiddlewareExtra extra) {
     logEvent(event, null, extra);
   }
 
@@ -176,7 +177,7 @@ public class Amplitude {
    * @param event The event to be sent
    * @param callbacks The callback for the event, this will run in addition to client level callback
    */
-  public synchronized void logEvent(Event event, AmplitudeCallbacks callbacks) {
+  public void logEvent(Event event, AmplitudeCallbacks callbacks) {
     logEvent(event, callbacks, null);
   }
 
@@ -187,7 +188,7 @@ public class Amplitude {
    * @param callbacks The callback for the event, this will run in addition to client level callback
    * @param extra The extra unstructured data for middleware
    */
-  public synchronized void logEvent(Event event, AmplitudeCallbacks callbacks, MiddlewareExtra extra) {
+  public void logEvent(Event event, AmplitudeCallbacks callbacks, MiddlewareExtra extra) {
     if (!middlewareRunner.run(new MiddlewarePayload(event, extra))) {
       return;
     }
@@ -195,8 +196,12 @@ public class Amplitude {
     if (callbacks != null) {
       event.callback = callbacks;
     }
-    eventsToSend.add(event);
-    if (eventsToSend.size() >= this.eventUploadThreshold) {
+    int queueSize = 0;
+    synchronized (eventQueueLock) {
+      eventsToSend.add(event);
+      queueSize = eventsToSend.size();
+    }
+    if (queueSize >= this.eventUploadThreshold) {
       flushEvents();
     } else {
       scheduleFlushEvents();
@@ -207,10 +212,15 @@ public class Amplitude {
    * Forces events currently in the event buffer to be sent to Amplitude API endpoint. Only one
    * thread may flush at a time. Next flushes will happen immediately after.
    */
-  public synchronized void flushEvents() {
-    if (eventsToSend.size() > 0) {
-      List<Event> eventsInTransit = new ArrayList<>(eventsToSend);
-      eventsToSend.clear();
+  public void flushEvents() {
+    List<Event> eventsInTransit = new ArrayList<>();
+    synchronized (eventQueueLock) {
+      if (eventsToSend.size() > 0) {
+        eventsInTransit.addAll(eventsToSend);
+        eventsToSend.clear();
+      }
+    }
+    if (!eventsInTransit.isEmpty()) {
       httpTransport.sendEventsWithRetry(eventsInTransit);
     }
   }
@@ -238,6 +248,11 @@ public class Amplitude {
     httpTransport.setRecordThrottledId(record);
   }
 
+  public void shutdown() {
+    flushEvents();
+    httpTransport.join();
+  }
+
   private void updateHttpCall(HttpCallMode updatedHttpCallMode) {
     httpCallMode = updatedHttpCallMode;
 
@@ -249,7 +264,7 @@ public class Amplitude {
     httpTransport.setHttpCall(httpCall);
   }
 
-  private void scheduleFlushEvents() {
+  private synchronized void scheduleFlushEvents() {
     if (!aboutToStartFlushing) {
       aboutToStartFlushing = true;
       Thread flushThread =
@@ -258,7 +273,7 @@ public class Amplitude {
                 try {
                   Thread.sleep(this.eventUploadPeriodMillis);
                 } catch (InterruptedException e) {
-
+                  logger.warn("Error schedule flush events.", e.getMessage());
                 }
                 flushEvents();
                 aboutToStartFlushing = false;

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -248,11 +248,6 @@ public class Amplitude {
     httpTransport.setRecordThrottledId(record);
   }
 
-  public void shutdown() {
-    flushEvents();
-    httpTransport.join();
-  }
-
   private void updateHttpCall(HttpCallMode updatedHttpCallMode) {
     httpCallMode = updatedHttpCallMode;
 

--- a/src/main/java/com/amplitude/Event.java
+++ b/src/main/java/com/amplitude/Event.java
@@ -238,12 +238,8 @@ public class Event {
       event.put("android_id", replaceWithJSONNull(androidId));
       event.put("language", replaceWithJSONNull(language));
       event.put("ip", replaceWithJSONNull(ip));
-      event.put(
-          "event_properties",
-          (eventProperties == null) ? new JSONObject() : truncate(eventProperties));
-      event.put(
-          "user_properties",
-          (userProperties == null) ? new JSONObject() : truncate(userProperties));
+      event.put("event_properties", truncate(eventProperties));
+      event.put("user_properties", truncate(userProperties));
 
       boolean shouldLogRevenueProps = (revenue != null || price != null);
       if (shouldLogRevenueProps) {

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -373,4 +373,8 @@ class HttpTransport {
         });
     return eventQueues.isEmpty() ? null : eventQueues.get(0);
   }
+
+  public boolean shoudWait() {
+      return eventsInRetry.intValue() >= Constants.MAX_CACHED_EVENTS;
+  }
 }

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -344,7 +344,7 @@ class HttpTransport {
         });
   }
 
-  private List<Event> getEventsFromBuffer(String userId, String deviceId) {
+  private synchronized List<Event> getEventsFromBuffer(String userId, String deviceId) {
     if (idToBuffer.containsKey(userId) && idToBuffer.get(userId).containsKey(deviceId)){
         return new ArrayList<>(idToBuffer.remove(userId).remove(deviceId));
     }

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -351,7 +351,7 @@ class HttpTransport {
   }
 
   public boolean shouldWait(Event event) {
-      if (throttledUserId.containsKey(event.userId) || throttledDeviceId.containsKey(event.deviceId)) {
+      if (recordThrottledId && (throttledUserId.containsKey(event.userId) || throttledDeviceId.containsKey(event.deviceId))) {
         return true;
       }
       return eventsInRetry >= Constants.MAX_CACHED_EVENTS;

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -190,6 +190,15 @@ class HttpTransport {
     List<Event> eventsToDrop = new ArrayList<>();
     // Filter invalid event out based on the response code.
     if (response.status == Status.INVALID) {
+      if ((response.invalidRequestBody != null
+              && response.invalidRequestBody.has("missingField")
+              && response.invalidRequestBody.getString("missingField").length() > 0)
+              || events.size() == 1) {
+        // Return early if there's an issue with the entire payload
+        // or if there's only one event and its invalid
+        triggerEventCallbacks(events, response.code, response.error);
+        return eventsToRetry;
+      }
       int[] invalidEventIndices = response.collectInvalidEventIndices();
       for (int i = 0; i < events.size(); i++) {
         if (Arrays.binarySearch(invalidEventIndices, i) < 0) {

--- a/src/test/java/com/amplitude/AmplitudeMultiThreadTest.java
+++ b/src/test/java/com/amplitude/AmplitudeMultiThreadTest.java
@@ -2,8 +2,8 @@ package com.amplitude;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;

--- a/src/test/java/com/amplitude/AmplitudeMultiThreadTest.java
+++ b/src/test/java/com/amplitude/AmplitudeMultiThreadTest.java
@@ -2,8 +2,8 @@ package com.amplitude;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -76,7 +76,7 @@ public class AmplitudeMultiThreadTest {
     Amplitude amplitude = Amplitude.getInstance("Multiple threads log event failure.");
     amplitude.init(apiKey);
     HttpCall httpCall = getMockHttpCall(amplitude);
-    Response payloadTooLargeResponse = ResponseUtil.getRateLimitResponse(false);
+    Response payloadTooLargeResponse = ResponseUtil.getPayloadTooLargeResponse();
     when(httpCall.makeRequest(anyList())).thenAnswer(invocation -> payloadTooLargeResponse);
     int total = 1000;
     CountDownCallbacks callbacks = new CountDownCallbacks(new CountDownLatch(total));

--- a/src/test/java/com/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/amplitude/AmplitudeTest.java
@@ -335,6 +335,12 @@ public class AmplitudeTest {
     assertEquals("middleware_user_2", sentEvent.userId);
   }
 
+  @Test public void testShouldWait() {
+    Amplitude amplitude = Amplitude.getInstance();
+    amplitude.init(apiKey);
+    assertFalse(amplitude.shouldWait(new Event("test event", "test-user-id")));
+  }
+
   private HttpCall getMockHttpCall(Amplitude amplitude, boolean useBatch)
       throws NoSuchFieldException, IllegalAccessException {
     HttpCall httpCall = mock(HttpCall.class);

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -301,7 +301,7 @@ public class HttpTransportTest {
                 };
         httpTransport.setHttpCall(httpCall);
         httpTransport.setCallbacks(callbacks);
-        httpTransport.sendEventsWithRetry(events);
+        httpTransport.retryEvents(events, ResponseUtil.getInvalidResponse(false));
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
         verify(httpCall, times(1)).makeRequest(anyList());
         for (int i = 0; i < events.size(); i++) {
@@ -333,7 +333,7 @@ public class HttpTransportTest {
                 };
         httpTransport.setHttpCall(httpCall);
         httpTransport.setCallbacks(callbacks);
-        httpTransport.sendEventsWithRetry(events);
+        httpTransport.retryEvents(events, ResponseUtil.getInvalidResponse(false));
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
         verify(httpCall, times(1)).makeRequest(anyList());
         for (int i = 0; i < events.size(); i++) {

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -98,7 +98,7 @@ public class HttpTransportTest {
       if (i < (events.size() / 2)) {
         assertEquals(200, resultMap.get(events.get(i)));
       } else {
-        assertEquals(429, resultMap.get(events.get(i)));
+        assertEquals(413, resultMap.get(events.get(i)));
       }
     }
   }

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -95,10 +95,12 @@ public class HttpTransportTest {
     assertTrue(latch.await(1L, TimeUnit.SECONDS));
     verify(httpCall, times(4)).makeRequest(anyList());
     for (int i = 0; i < events.size(); i++) {
-      if (i < (events.size() / 2)) {
+      if (i < (events.size() / 4)) {
         assertEquals(200, resultMap.get(events.get(i)));
+      } else if (i < (events.size() / 2)) {
+          assertEquals(413, resultMap.get(events.get(i)));
       } else {
-        assertEquals(413, resultMap.get(events.get(i)));
+        assertEquals(429, resultMap.get(events.get(i)));
       }
     }
   }

--- a/src/test/java/com/amplitude/OptionsTest.java
+++ b/src/test/java/com/amplitude/OptionsTest.java
@@ -1,0 +1,16 @@
+package com.amplitude;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OptionsTest {
+    @Test
+    public void testOptions() {
+        Options option = new Options();
+        option.minIdLength = 5;
+        JSONObject optionJson = option.toJsonObject();
+        assertEquals(5, optionJson.getInt("min_id_length"));
+    }
+}

--- a/src/test/java/com/amplitude/ResponseUtil.java
+++ b/src/test/java/com/amplitude/ResponseUtil.java
@@ -43,10 +43,10 @@ class ResponseUtil {
     if (withExceedQuota) {
       rateLimitResponse.rateLimitBody = new JSONObject();
       JSONObject exceededDailyQuotaUsers = new JSONObject();
-      exceededDailyQuotaUsers.put("test-user-id-0", true);
+      exceededDailyQuotaUsers.put("test-user-id-0", 19);
       rateLimitResponse.rateLimitBody.put("exceededDailyQuotaUsers", exceededDailyQuotaUsers);
       JSONObject exceededDailyQuotaDevices = new JSONObject();
-      exceededDailyQuotaDevices.put("test-device", true);
+      exceededDailyQuotaDevices.put("test-device", 28);
       rateLimitResponse.rateLimitBody.put("exceededDailyQuotaDevices", exceededDailyQuotaDevices);
     }
     return rateLimitResponse;


### PR DESCRIPTION
### Summary

1.  add an example in Demo package src/demo/java/com/demo/amplitude/LocalUploadDemo.java showing a use case upload bulk amount of events locally with a script using java SDK.
2. Amplitude client: add a method shouldWait(event), return true if the client was busy or event's userId or deviceId was throttled recently.
3. Amplitude client: change logEvent and flushEvents to non synchronized. Manage events queue multithread access by object lock.
4. Change scheduleFlushEvents method to synchronized to prevent creation of multiple flush threads.
5. HttpTransport class: retry using a thread pool.
6. HttpTransport class: fix issue of missing callbacks for events dropped because of retry buffer size limit.
7. HttpTransport class: fix error of counting events in buffer
8. HttpTransport class: fix bug of not reduce payload size of payload too large response
9. HttpTransport class: fix bug of dropping wrong events in the retry process.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: yes