### PR TITLE
feat: add a demo for customer who wants to send large amount of historical events using batch mode

### DIFF
--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -10,46 +10,50 @@ import java.util.concurrent.TimeUnit;
 
 public class LocalUploadDemo {
 
-    public static void main(String[] args) throws InterruptedException{
-        // Create and initialize Amplitude client
-        Amplitude client = Amplitude.getInstance();
-        client.init("");
+  public static void main(String[] args) throws InterruptedException {
+    // Create and initialize Amplitude client
+    Amplitude client = Amplitude.getInstance();
+    client.init("");
 
-        // use batch mode for higher throttling limits
-        client.useBatchMode(true);
+    // use batch mode for higher throttling limits
+    client.useBatchMode(true);
 
-        // this config can print debug info into console, including response body of each requests
-        client.setLogMode(AmplitudeLog.LogMode.DEBUG);
+    // this config can print debug info into console, including response body of each requests
+    client.setLogMode(AmplitudeLog.LogMode.DEBUG);
 
-        // for large amount of events to send, config a higher update threshold to upload more events in one request
-        // payload size limit for batch api is 20MB, max events per request is 2000
-        // https://developers.amplitude.com/docs/batch-event-upload-api#feature-comparison-between-httpapi-2httpapi--batch
-        client.setEventUploadThreshold(1500);
+    // for large amount of events to send, config a higher update threshold to upload more events in
+    // one request
+    // payload size limit for batch api is 20MB, max events per request is 2000
+    // https://developers.amplitude.com/docs/batch-event-upload-api#feature-comparison-between-httpapi-2httpapi--batch
+    client.setEventUploadThreshold(1500);
 
-        // config client to record throttled userId and deviceId. shouldWait(event) will return true if userid or deviceid was throttled
-        // can wait a short period of time and continue
-        client.setRecordThrottledId(true);
-        AmplitudeCallbacks callback = new AmplitudeCallbacks() {
-            @Override
-            public void onLogEventServerResponse(Event event, int status, String message) {
-                // call back functions here
-                System.out.println(event.eventType + " " + event.userId + " " + status + " " + message);
-            }
+    // config client to record throttled userId and deviceId. shouldWait(event) will return true if
+    // userid or deviceid was throttled
+    // can wait a short period of time and continue
+    client.setRecordThrottledId(true);
+    AmplitudeCallbacks callback =
+        new AmplitudeCallbacks() {
+          @Override
+          public void onLogEventServerResponse(Event event, int status, String message) {
+            // call back functions here
+            System.out.println(event.eventType + " " + event.userId + " " + status + " " + message);
+          }
         };
-        client.setCallbacks(callback);
-        for (int i = 0; i < 10000000; i++){
-            Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B" + (i % 5000));
-            while (client.shouldWait(ampEvent)) {
-                System.out.println("Client is busy. Waiting for log event " + ampEvent.eventType);
-                TimeUnit.SECONDS.sleep(60L);
-            }
-            ampEvent.userProperties = new JSONObject()
-                    .put("property1", "p"+i)
-                    .put("property2", "p"+i)
-                    .put("property3", "p"+i)
-                    .put("property4", "p"+i)
-                    .put("property5", "p"+i);
-            client.logEvent(ampEvent);
-        }
+    client.setCallbacks(callback);
+    for (int i = 0; i < 10000000; i++) {
+      Event ampEvent = new Event("General" + (i % 20), "Test_UserID_B" + (i % 5000));
+      while (client.shouldWait(ampEvent)) {
+        System.out.println("Client is busy. Waiting for log event " + ampEvent.eventType);
+        TimeUnit.SECONDS.sleep(60L);
+      }
+      ampEvent.userProperties =
+          new JSONObject()
+              .put("property1", "p" + i)
+              .put("property2", "p" + i)
+              .put("property3", "p" + i)
+              .put("property4", "p" + i)
+              .put("property5", "p" + i);
+      client.logEvent(ampEvent);
     }
+  }
 }

--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -41,7 +41,7 @@ public class LocalUploadDemo {
             Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B" + (i % 5000));
             while (client.shouldWait(ampEvent)) {
                 System.out.println("Client is busy. Waiting for log event " + ampEvent.eventType);
-                TimeUnit.SECONDS.sleep(5L);
+                TimeUnit.SECONDS.sleep(60L);
             }
             ampEvent.userProperties = new JSONObject()
                     .put("property1", "p"+i)

--- a/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
+++ b/src/demo/java/com/demo/amplitude/LocalUploadDemo.java
@@ -1,0 +1,55 @@
+package com.demo.amplitude;
+
+import com.amplitude.Amplitude;
+import com.amplitude.AmplitudeCallbacks;
+import com.amplitude.AmplitudeLog;
+import com.amplitude.Event;
+import org.json.JSONObject;
+
+import java.util.concurrent.TimeUnit;
+
+public class LocalUploadDemo {
+
+    public static void main(String[] args) throws InterruptedException{
+        // Create and initialize Amplitude client
+        Amplitude client = Amplitude.getInstance();
+        client.init("");
+
+        // use batch mode for higher throttling limits
+        client.useBatchMode(true);
+
+        // this config can print debug info into console, including response body of each requests
+        client.setLogMode(AmplitudeLog.LogMode.DEBUG);
+
+        // for large amount of events to send, config a higher update threshold to upload more events in one request
+        // payload size limit for batch api is 20MB, max events per request is 2000
+        // https://developers.amplitude.com/docs/batch-event-upload-api#feature-comparison-between-httpapi-2httpapi--batch
+        client.setEventUploadThreshold(1500);
+
+        // config client to record throttled userId and deviceId. shouldWait(event) will return true if userid or deviceid was throttled
+        // can wait a short period of time and continue
+        client.setRecordThrottledId(true);
+        AmplitudeCallbacks callback = new AmplitudeCallbacks() {
+            @Override
+            public void onLogEventServerResponse(Event event, int status, String message) {
+                // call back functions here
+                System.out.println(event.eventType + " " + event.userId + " " + status + " " + message);
+            }
+        };
+        client.setCallbacks(callback);
+        for (int i = 0; i < 10000000; i++){
+            Event ampEvent = new Event("General"+ (i % 20), "Test_UserID_B" + (i % 5000));
+            while (client.shouldWait(ampEvent)) {
+                System.out.println("Client is busy. Waiting for log event " + ampEvent.eventType);
+                TimeUnit.SECONDS.sleep(5L);
+            }
+            ampEvent.userProperties = new JSONObject()
+                    .put("property1", "p"+i)
+                    .put("property2", "p"+i)
+                    .put("property3", "p"+i)
+                    .put("property4", "p"+i)
+                    .put("property5", "p"+i);
+            client.logEvent(ampEvent);
+        }
+    }
+}

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -215,6 +215,29 @@ public class Amplitude {
     }
   }
 
+  /**
+   * Check the status of the client, return true if any of the following situation:
+   * 1. Events sit in memory waiting for flush are more than flush threshold
+   * 2. Events in retry buffer are more than 16,000
+   * 3. When setRecordThrottledId(true), the userId or deviceId of the input event was throttled and retry attempt for the userId/deviceId not finished.
+   * Can be called before logEvent(event) and add some wait time if return true.
+   *
+   * @param event The event to be sent.
+   * @return true if client is busy or event may be throttled.
+   */
+  public boolean shouldWait(Event event) {
+    return eventsToSend.size() > eventUploadThreshold || httpTransport.shouldWait(event);
+  }
+
+  /**
+   * Config whether the client record the recent throttled userId/deviceId and make suggestion base on it.
+   *
+   * @param record true to record
+   */
+  public void setRecordThrottledId(boolean record) {
+    httpTransport.setRecordThrottledId(record);
+  }
+
   private void updateHttpCall(HttpCallMode updatedHttpCallMode) {
     httpCallMode = updatedHttpCallMode;
 

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -277,14 +277,12 @@ class HttpTransport {
       for (Event event : events) {
         if (!(response.isUserOrDeviceExceedQuote(event.userId, event.deviceId))) {
           eventsToRetry.add(event);
-        } else {
-          eventsToDrop.add(event);
           if (recordThrottledId) {
             try {
               JSONObject throttledUser =
-                  response.rateLimitBody.getJSONObject("exceededDailyQuotaUsers");
+                      response.rateLimitBody.getJSONObject("throttledUsers");
               JSONObject throttledDevice =
-                  response.rateLimitBody.getJSONObject("exceededDailyQuotaDevices");
+                      response.rateLimitBody.getJSONObject("throttledDevices");
               synchronized (throttleLock) {
                 if (throttledUser.has(event.userId)) {
                   throttledUserId.put(event.userId, throttledUser.getInt(event.userId));
@@ -297,6 +295,8 @@ class HttpTransport {
               logger.debug("THROTTLED", "Error get throttled userId or deviceId");
             }
           }
+        } else {
+          eventsToDrop.add(event);
         }
       }
       triggerEventCallbacks(eventsToDrop, response.code, "User or Device Exceed Daily Quota.");

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -61,9 +61,9 @@ class HttpTransport {
               } else if (status == Status.SUCCESS) {
                 triggerEventCallbacks(events, response.code, "Event sent success.");
               } else if (status == Status.FAILED) {
-                  triggerEventCallbacks(events, response.code, "Event sent Failed.");
-              }  else {
-                  triggerEventCallbacks(events, response.code, "Unknown response status.");
+                triggerEventCallbacks(events, response.code, "Event sent Failed.");
+              } else {
+                triggerEventCallbacks(events, response.code, "Unknown response status.");
               }
             })
         .exceptionally(
@@ -281,8 +281,10 @@ class HttpTransport {
           eventsToDrop.add(event);
           if (recordThrottledId) {
             try {
-              JSONObject throttledUser = response.rateLimitBody.getJSONObject("exceededDailyQuotaUsers");
-              JSONObject throttledDevice = response.rateLimitBody.getJSONObject("exceededDailyQuotaDevices");
+              JSONObject throttledUser =
+                  response.rateLimitBody.getJSONObject("exceededDailyQuotaUsers");
+              JSONObject throttledDevice =
+                  response.rateLimitBody.getJSONObject("exceededDailyQuotaDevices");
               synchronized (throttleLock) {
                 if (throttledUser.has(event.userId)) {
                   throttledUserId.put(event.userId, throttledUser.getInt(event.userId));
@@ -407,7 +409,9 @@ class HttpTransport {
   }
 
   public boolean shouldWait(Event event) {
-    if (recordThrottledId && (throttledUserId.containsKey(event.userId) || throttledDeviceId.containsKey(event.deviceId))) {
+    if (recordThrottledId
+        && (throttledUserId.containsKey(event.userId)
+            || throttledDeviceId.containsKey(event.deviceId))) {
       return true;
     }
     return eventsInRetry.intValue() >= Constants.MAX_CACHED_EVENTS;

--- a/src/main/java/com/amplitude/Response.java
+++ b/src/main/java/com/amplitude/Response.java
@@ -72,8 +72,8 @@ public class Response {
     if (status == Status.RATELIMIT && rateLimitBody != null) {
       JSONObject exceededDailyQuotaUsers = rateLimitBody.getJSONObject("exceededDailyQuotaUsers");
       JSONObject exceededDailyQuotaDevices = rateLimitBody.getJSONObject("exceededDailyQuotaDevices");
-      if ((userId.length() > 0 && exceededDailyQuotaUsers.has(userId))
-          || (deviceId.length() > 0 && exceededDailyQuotaDevices.has(deviceId))) {
+      if ((userId != null && userId.length() > 0 && exceededDailyQuotaUsers.has(userId))
+          || (deviceId != null && deviceId.length() > 0 && exceededDailyQuotaDevices.has(deviceId))) {
         return true;
       }
     }

--- a/src/test/java/com/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/amplitude/AmplitudeTest.java
@@ -352,7 +352,7 @@ public class AmplitudeTest {
     HttpCall httpCall = getMockHttpCall(amplitude, false);
     CyclicBarrier barrier = new CyclicBarrier(2);
     CountDownLatch latch = new CountDownLatch(1);
-    CountDownLatch callcakkLatch = new CountDownLatch(2);
+    CountDownLatch callbakkLatch = new CountDownLatch(2);
     Response response = new Response();
     response.status = Status.RATELIMIT;
     response.code = 429;
@@ -385,7 +385,7 @@ public class AmplitudeTest {
         new AmplitudeCallbacks() {
           @Override
           public void onLogEventServerResponse(Event event, int status, String message) {
-            callcakkLatch.countDown();
+            callbakkLatch.countDown();
           }
         });
     amplitude.logEvent(event);
@@ -395,7 +395,7 @@ public class AmplitudeTest {
     assertTrue(amplitude.shouldWait(event));
     assertFalse(amplitude.shouldWait(event2));
     barrier.await();
-    assertTrue(callcakkLatch.await(1L, TimeUnit.SECONDS));
+    assertTrue(callbakkLatch.await(1L, TimeUnit.SECONDS));
     assertFalse(amplitude.shouldWait(event));
     assertFalse(amplitude.shouldWait(event2));
   }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Java SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

1. add an example in Demo package src/demo/java/com/demo/amplitude/LocalUploadDemo.java showing a use case upload bulk amount of events locally with a script using java SDK.
2. Amplitude client: add a method shouldWait(event), return true if the client was busy or event's userId or deviceId was throttled recently.
3. Amplitude client: add a method setRecordThrottledId(boolean). Config whether shouldWait() method use recent throttled userId/deviceId or not.

### Checklist

* [X ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:   no 