### PR TITLE
fix: issue of possible drop wrong event and error counting events in retry buffer

### DIFF
--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -230,6 +230,7 @@ class HttpTransport {
         break;
       case PAYLOAD_TOO_LARGE:
         shouldRetry = true;
+        shouldReduceEventCount = true;
         break;
       case INVALID:
         if (events.size() == 1) {
@@ -238,6 +239,14 @@ class HttpTransport {
         } else {
           eventIndicesToRemove = response.collectInvalidEventIndices();
         }
+        break;
+      case UNKNOWN:
+        shouldRetry = false;
+        triggerEventCallbacks(events, response.code, "Unknown response status.");
+        break;
+      case FAILED:
+        shouldRetry = false;
+        triggerEventCallbacks(events, response.code, "Event sent Failed.");
         break;
       default:
         break;

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -78,7 +78,7 @@ class HttpTransport {
       if (eventsInRetry.get() < Constants.MAX_CACHED_EVENTS) {
           onEventsError(events, response);
       } else {
-          String message = "Retry buffer is full, events dropped.";
+          String message = "Retry buffer is full(" + eventsInRetry.get() + "), " + events.size() + " events dropped.";
           logger.warn("DROP EVENTS", message);
           triggerEventCallbacks(events, response.code, message);
       }


### PR DESCRIPTION

### Summary

1. add callback for events dropped because of events buffer size limit
2. remove prune method. This method remove events from list and the list will later be used by looking for events by old list index. Result in drop wrong events of index out of bound exception
3. Increase counter in addEventToBuffer method

### Checklist

* [X ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no