### PR TITLE
feat: add library context field

### DIFF
--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -24,6 +24,7 @@ public class Amplitude {
   private Object eventQueueLock = new Object();
   private Plan plan;
   private long flushTimeout;
+  private String libraryContext;
 
   /**
    * A dictionary of key-value pairs that represent additional instructions for server save
@@ -164,6 +165,16 @@ public class Amplitude {
   }
 
   /**
+   * Set library context information.
+   *
+   * @param libraryContext String
+   */
+  public Amplitude setLibraryContext(String libraryContext) {
+    this.libraryContext = libraryContext;
+    return this;
+  }
+
+  /**
    * Set custom proxy for https requests
    *
    * @param proxy Proxy object, default to Proxy.NO_PROXY for direct connection
@@ -240,6 +251,10 @@ public class Amplitude {
   public void logEvent(Event event, AmplitudeCallbacks callbacks, MiddlewareExtra extra) {
     if (event.plan == null) {
       event.plan = this.plan;
+    }
+
+    if (event.libraryContext == null) {
+      event.libraryContext = this.libraryContext;
     }
 
     if (!middlewareRunner.run(new MiddlewarePayload(event, extra))) {

--- a/src/main/java/com/amplitude/Event.java
+++ b/src/main/java/com/amplitude/Event.java
@@ -184,6 +184,11 @@ public class Event {
   public Plan plan;
 
   /**
+   * The library context information.
+   */
+  public String libraryContext;
+
+  /**
    * Callback for Event
    */
   protected AmplitudeCallbacks callback;
@@ -278,6 +283,10 @@ public class Event {
 
       if (plan != null) {
         event.put("plan", plan.toJSONObject());
+      }
+
+      if (libraryContext != null) {
+        event.put("library_context", libraryContext);
       }
     } catch (JSONException e) {
       e.printStackTrace();

--- a/src/test/java/com/amplitude/EventTest.java
+++ b/src/test/java/com/amplitude/EventTest.java
@@ -52,6 +52,7 @@ public class EventTest {
     assertEquals(
         Constants.SDK_LIBRARY + "/" + Constants.SDK_VERSION, truncatedEvent.getString("library"));
     assertEquals(-1, truncatedEvent.getLong("session_id"));
+    assertFalse(truncatedEvent.has("library_context"));
   }
 
   @Test


### PR DESCRIPTION
### Summary
- feat: add library context field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `library_context` information.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No