### PR TITLE
Chore(deps): Patch CVE-2022-45688 vulnerability

### DIFF
--- a/src/demo/build.gradle
+++ b/src/demo/build.gradle
@@ -27,7 +27,7 @@ idea {
 sourceSets.main.java.srcDirs = ['java']
 
 dependencies {
-    implementation 'org.json:json:20220320'
+    implementation 'org.json:json:20230227'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation project(':main')
 }

--- a/src/main/build.gradle
+++ b/src/main/build.gradle
@@ -32,7 +32,7 @@ idea {
 sourceSets.main.java.srcDirs = ['java']
 
 dependencies {
-    implementation 'org.json:json:20220320'
+    implementation 'org.json:json:20230227'
 }
 
 java {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Java SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Simple bump to the org.json:json dependency to [20230227](https://github.com/stleary/JSON-java/releases/tag/20230227) version which patches [CVE-2022-45688](https://github.com/advisories/GHSA-3vqj-43w4-2q58) vulnerability.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  yes, afaik 20230227 should be backward backward compatible.