### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Do a dry run to preview instead of a real release'
+        required: true
+        default: 'true'
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [authorize]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Test
+        run: ./gradlew test --info
+
+      - name: Configure GPG
+        run: |
+          echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > 'secring.gpg'
+
+      - name: Semantic Release --dry-run
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1 \
+          -p @semantic-release/exec@5 \
+          semantic-release --dry-run
+
+      - name: Semantic Release
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          SECURE_REPO_USER: ${{ secrets.OSSRH_USERNAME }}
+          SECURE_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_RING_FILE: ../../secring.gpg
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1 \
+          -p @semantic-release/exec@5 \
+          semantic-release

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,69 @@
+module.exports = {
+  "branches": [
+    {name: 'beta', prerelease: true},
+    "main"
+  ],
+  "tagFormat": ["v${version}"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+      }
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "angular",
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/github",
+    [
+      "@google/semantic-release-replace-plugin",
+      {
+        "replacements": [
+          {
+            "files": ["gradle.properties"],
+            "from": "ARTIFACT_VERSION=.*",
+            "to": "ARTIFACT_VERSION=${nextRelease.version}",
+            "results": [
+              {
+                "file": "gradle.properties",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
+          {
+            "files": ["src/main/java/com/amplitude/Constants.java"],
+            "from": "String SDK_VERSION = \".*\";",
+            "to": "String SDK_VERSION = \"${nextRelease.version}\";",
+            "results": [
+              {
+                "file": "src/main/java/com/amplitude/Constants.java",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
+        ]
+      }
+    ],
+    ["@semantic-release/git", {
+      "assets": ["gradle.properties", "CHANGELOG.md", "src/main/java/com/amplitude/Constants.java"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    ["@semantic-release/exec", {
+      "publishCmd": `./gradlew publishMavenJavaPublicationToMySecureRepository \
+        -PmySecureRepositoryUsername="$SECURE_REPO_USER" \
+        -PmySecureRepositoryPassword="$SECURE_REPO_PASSWORD" \
+        -Psigning.keyId="$SIGNING_KEY_ID" \
+        -Psigning.password="$SIGNING_PASSWORD" \
+        -Psigning.secretKeyRingFile="$SIGNING_SECRET_RING_FILE"`,
+    }],
+  ],
+}


### PR DESCRIPTION
### Summary

Add a github workflow to automate release.

1. Based on Amplitude-Android workflow (https://github.com/amplitude/Amplitude-Android/blob/main/.github/workflows/release.yml)
2. Secrets `OSSRH_PASSWORD`, `OSSRH_USERNAME`, `SIGNING_KEY_ID`, `SIGNING_PASSWORD`, `GPG_KEY_CONTENTS` should be added (as in Amplitude-Android)
3. Deploy key and additional secret `DEPLOY_KEY` with private part of the key should be added (`main` branch is protected in Amplitude-Java)
4. The workflow covers Step 2 in "Java/Android Build Tooling Processes [WIP]" (except `gradle publish ...` command - is it required?). Step 3 "Close and release the Java artifact" should be run manually.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No