### PR TITLE
fix: use sendThreadPool in sendEvents

### DIFF
--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -3,6 +3,7 @@ package com.amplitude;
 import java.net.Proxy;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
 
 public class Amplitude {
   private static Map<String, Amplitude> instances = new HashMap<>();
@@ -24,6 +25,8 @@ public class Amplitude {
   private Plan plan;
   private IngestionMetadata ingestionMetadata;
   private long flushTimeout;
+  private ExecutorService retryThreadPool;
+  private ExecutorService sendThreadPool;
 
   /**
    * A dictionary of key-value pairs that represent additional instructions for server save
@@ -46,7 +49,7 @@ public class Amplitude {
     logger = new AmplitudeLog();
     eventsToSend = new ConcurrentLinkedQueue<>();
     aboutToStartFlushing = false;
-    httpTransport = new HttpTransport(httpCall, null, logger, flushTimeout);
+    httpTransport = new HttpTransport(httpCall, null, logger, flushTimeout, sendThreadPool, retryThreadPool);
   }
 
   /**
@@ -203,6 +206,28 @@ public class Amplitude {
   public Amplitude setFlushTimeout(long timeout) {
     flushTimeout = timeout;
     this.httpTransport.setFlushTimeout(timeout);
+    return this;
+  }
+
+  /**
+   * Set the thread pool for sending events via {@link HttpTransport}
+   *
+   * @param sendThreadPool the thread pool for sending events
+   */
+  public Amplitude setSendThreadPool(ExecutorService sendThreadPool) {
+    this.sendThreadPool = sendThreadPool;
+    this.httpTransport.setSendThreadPool(sendThreadPool);
+    return this;
+  }
+
+  /**
+   * Set the thread pool for retrying events via {@link HttpTransport}
+   *
+   * @param retryThreadPool the thread pool for retrying events
+   */
+  public Amplitude setRetryThreadPool(ExecutorService retryThreadPool) {
+    this.retryThreadPool = retryThreadPool;
+    this.httpTransport.setRetryThreadPool(retryThreadPool);
     return this;
   }
 

--- a/src/main/java/com/amplitude/Amplitude.java
+++ b/src/main/java/com/amplitude/Amplitude.java
@@ -25,8 +25,6 @@ public class Amplitude {
   private Plan plan;
   private IngestionMetadata ingestionMetadata;
   private long flushTimeout;
-  private ExecutorService retryThreadPool;
-  private ExecutorService sendThreadPool;
 
   /**
    * A dictionary of key-value pairs that represent additional instructions for server save
@@ -49,7 +47,7 @@ public class Amplitude {
     logger = new AmplitudeLog();
     eventsToSend = new ConcurrentLinkedQueue<>();
     aboutToStartFlushing = false;
-    httpTransport = new HttpTransport(httpCall, null, logger, flushTimeout, sendThreadPool, retryThreadPool);
+    httpTransport = new HttpTransport(httpCall, null, logger, flushTimeout);
   }
 
   /**
@@ -215,7 +213,6 @@ public class Amplitude {
    * @param sendThreadPool the thread pool for sending events
    */
   public Amplitude setSendThreadPool(ExecutorService sendThreadPool) {
-    this.sendThreadPool = sendThreadPool;
     this.httpTransport.setSendThreadPool(sendThreadPool);
     return this;
   }
@@ -226,7 +223,6 @@ public class Amplitude {
    * @param retryThreadPool the thread pool for retrying events
    */
   public Amplitude setRetryThreadPool(ExecutorService retryThreadPool) {
-    this.retryThreadPool = retryThreadPool;
     this.httpTransport.setRetryThreadPool(retryThreadPool);
     return this;
   }

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -46,7 +46,8 @@ class HttpTransport {
 
   // Managed by setters
   private ExecutorService retryThreadPool = Executors.newFixedThreadPool(10);
-  private ExecutorService sendThreadPool = Executors.newFixedThreadPool(40);
+  private ExecutorService sendThreadPool = Executors.newFixedThreadPool(20);
+  private ExecutorService supplyAsyncPool = Executors.newCachedThreadPool();
 
   HttpTransport(
       HttpCall httpCall, AmplitudeCallbacks callbacks, AmplitudeLog logger, long flushTimeout) {
@@ -126,7 +127,7 @@ class HttpTransport {
             throw new CompletionException(e);
           }
           return response;
-        }, sendThreadPool);
+        }, supplyAsyncPool);
   }
 
   // Call this function if event not in current Retry list.

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -38,23 +38,22 @@ class HttpTransport {
   private int eventsInRetry = 0;
   private Object bufferLock = new Object();
   private Object counterLock = new Object();
-  private ExecutorService retryThreadPool;
-  private ExecutorService sendThreadPool;
 
   private HttpCall httpCall;
   private AmplitudeLog logger;
   private AmplitudeCallbacks callbacks;
   private long flushTimeout;
 
+  // Managed by setters
+  private ExecutorService retryThreadPool = Executors.newFixedThreadPool(10);
+  private ExecutorService sendThreadPool = Executors.newFixedThreadPool(40);
+
   HttpTransport(
-      HttpCall httpCall, AmplitudeCallbacks callbacks, AmplitudeLog logger,
-      long flushTimeout, ExecutorService sendThreadPool, ExecutorService retryThreadPool) {
+      HttpCall httpCall, AmplitudeCallbacks callbacks, AmplitudeLog logger, long flushTimeout) {
     this.httpCall = httpCall;
     this.callbacks = callbacks;
     this.logger = logger;
     this.flushTimeout = flushTimeout;
-    this.retryThreadPool = (retryThreadPool == null) ? Executors.newFixedThreadPool(10) : retryThreadPool;
-    this.sendThreadPool = (sendThreadPool == null) ? Executors.newFixedThreadPool(40) : sendThreadPool;
   }
 
   public void sendEventsWithRetry(List<Event> events) {

--- a/src/main/java/com/amplitude/HttpTransport.java
+++ b/src/main/java/com/amplitude/HttpTransport.java
@@ -46,6 +46,12 @@ class HttpTransport {
 
   // Managed by setters
   private ExecutorService retryThreadPool = Executors.newFixedThreadPool(10);
+
+  // The supplyAsyncPool is only used within the sendThreadPool so only when
+  // the sendThreadPool is increased will the supplyAsyncPool be more utilized.
+  // We are using the supplyAsyncPool rather than the default fork join common
+  // pool because the fork join common pool scales with cpu... and we do not
+  // want to perform network requests in that small pool.
   private ExecutorService sendThreadPool = Executors.newFixedThreadPool(20);
   private ExecutorService supplyAsyncPool = Executors.newCachedThreadPool();
 

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +62,7 @@ public class HttpTransportTest {
     }).when(sendThreadPool).execute(any());
     httpTransport.setSendThreadPool(sendThreadPool);
     httpTransport.setHttpCall(httpCall);
-    httpTransport.sendEventsWithRetry(List.of());
+    httpTransport.sendEventsWithRetry(new ArrayList<>());
     assertTrue(latch.await(2L, TimeUnit.SECONDS));
   }
 

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -2,23 +2,17 @@ package com.amplitude;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,8 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amplitude.exception.AmplitudeInvalidAPIKeyException;
 import com.amplitude.util.EventsGenerator;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 public class HttpTransportTest {
@@ -41,29 +33,6 @@ public class HttpTransportTest {
   @BeforeEach
   public void setUp() {
     httpTransport = new HttpTransport(null, null, new AmplitudeLog(), 0);
-  }
-
-  /**
-   * This test is to make sure the same thread pool is used in both sendEventsWithRetry -> sendEvents.
-   * If the thread pool is not piped to sendEvents, then the default ForkJoinPool is used which can
-   * become a performance bottleneck.
-   */
-  @Test
-  @MockitoSettings(strictness = Strictness.LENIENT)
-  public void testSentEventsThreadpool() throws AmplitudeInvalidAPIKeyException, InterruptedException{
-    CountDownLatch latch = new CountDownLatch(2);
-    HttpCall httpCall = mock(HttpCall.class);
-    when(httpCall.makeRequest(anyList())).thenReturn(ResponseUtil.getSuccessResponse());
-    ExecutorService sendThreadPool = spy(Executors.newFixedThreadPool(2));
-    doAnswer((invocation) -> {
-      latch.countDown();
-      invocation.callRealMethod();
-      return null;
-    }).when(sendThreadPool).execute(any());
-    httpTransport.setSendThreadPool(sendThreadPool);
-    httpTransport.setHttpCall(httpCall);
-    httpTransport.sendEventsWithRetry(new ArrayList<>());
-    assertTrue(latch.await(2L, TimeUnit.SECONDS));
   }
 
   @ParameterizedTest

--- a/src/test/java/com/amplitude/HttpTransportTest.java
+++ b/src/test/java/com/amplitude/HttpTransportTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amplitude.exception.AmplitudeInvalidAPIKeyException;
@@ -40,7 +39,7 @@ public class HttpTransportTest {
 
   @BeforeEach
   public void setUp() {
-    httpTransport = new HttpTransport(null, null, new AmplitudeLog(), 0, null, null);
+    httpTransport = new HttpTransport(null, null, new AmplitudeLog(), 0);
   }
 
   /**


### PR DESCRIPTION
### Summary

Issue https://github.com/amplitude/Amplitude-Java/issues/108

This PR consists of 2 main changes to address a performance bottleneck in the Amplitude client:
(1) Pass cached thread pool to supplyAsync 
(2) Allow users to set `sendThreadPool` and `retryThreadPool`

During performance testing it was found Amplitude client would bottleneck on the default ForkJoinPool invoked indirectly via `CompletableFuture.supplyAsync(runnable)` which is not ideal for I/O:

![Screenshot 2024-08-27 at 4 06 44 PM](https://github.com/user-attachments/assets/a0917572-0ae3-4409-bb50-c8cd8081e92f)

Many threads were parked due to Amplitude during testing and increasing the fork join pool resolved the issue.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no